### PR TITLE
updated to remove former team

### DIFF
--- a/_includes/about-team.html
+++ b/_includes/about-team.html
@@ -18,26 +18,6 @@
 	{% endfor %}
 </section>
 
-<h2 class="sectionTitle">Former Team Members</h2>
-<section class="team-container row">
-	{% for person in site.data.team %}
-	{% unless person.current %}
-	<div class="team-personContainer col-xs-12 col-md-3">
-		{% if jekyll.environment == 'production' and site.cloudinary_url %}
-		<img src="{{ person.image | prepend: site.url | prepend: site.cloudinary_url }}"
-			title="{{ page.feature_image_credit }}" alt="{{ page.feature_image_credit }}" />
-		{% else %}
-		<img src="{{ person.image | default:'/assets/img/anon-author.svg' | relative_url }}"
-			alt='{{ person.name }} Image' />
-		{% endif %}
-		<br />
-		<strong class="team-name">{{ person.name }}</strong><br />
-		<span class="team-title">{{ person.title | escape }}</span>
-	</div>
-	{% endunless %}
-	{% endfor %}
-</section>
-
 <section class="ilab-container">
 	<h2 class="sectionTitle">Development Team</h2>
 	<p><em>Engaging Indian States</em> is a product of the <a href="www.csis.org/programs/dracopoulos-ideas-lab"


### PR DESCRIPTION
removes "former team members" part of about page